### PR TITLE
fix the priority ordering so that 1 goes before 10

### DIFF
--- a/util.js
+++ b/util.js
@@ -60,6 +60,6 @@ module.exports = {
     sortByPriority(prev, next) {
         let prevPriority = prev.priority || prev.default.priority;
         let nextPriority = next.priority || next.default.priority;
-        return nextPriority - prevPriority;
+        return prevPriority - nextPriority;
     }
 };


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
If compareFunction(a, b) returns less than 0, sort a to an index lower than b (i.e. a comes first).