### PR TITLE
fix: removing console.logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs   = require('fs').promises;
 
 module.exports = async (app, path = `${__dirname}/../../initializers`) => {
     const initializers = await fs.readdir(path);
-    console.log(initializers)
+    // console.log(initializers)
     const preparedInitializers = initializers
     .filter(util.filterIndex)
     .map(fileName => {
@@ -13,7 +13,7 @@ module.exports = async (app, path = `${__dirname}/../../initializers`) => {
         return file;
     })
     .sort(util.sortByPriority);
-    console.log(preparedInitializers)
+    // console.log(preparedInitializers)
     for (const initializer of preparedInitializers) {
         let execute = initializer.execute || initializer.default.execute;
         // console.log('EXECUTING')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-initializer",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
In the recent release two console.logs were added. I think they should be removed.